### PR TITLE
Update setup_heroku script

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -247,11 +247,9 @@ Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
-  if Rails.env.production? && ENV['DEVISE_SECRET_KEY'].blank?
-    raise 'The DEVISE_SECRET_KEY environment variable is not set on your production' \
-    ' server. To generate a random key, run "rake secret" from the command' \
-    ' line, then set it in production. If you\'re using Heroku, you can set it ' \
-    'like this: "heroku config:set DEVISE_SECRET_KEY=the_key_you_generated".'
-  end
-  config.secret_key = ENV['DEVISE_SECRET_KEY'] || '8615cc909c91b598763a62a225815abfd728327063baf6a1c15bbc7aacc747fd91c81e9a03b003af95c5a856de844738d26ae057b014ae6c2807c4f9168008ab'
+  #
+  # DEPRECATED: Recent versions of Devise will use the Rails secret_key_base in
+  # Rails 4+, so this setting should not be used. It is left here to allow
+  # deployments to control when their existing tokens are invalidated.
+  config.secret_key = ENV['DEVISE_SECRET_KEY']
 end

--- a/script/setup_heroku
+++ b/script/setup_heroku
@@ -1,45 +1,49 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
+set -ue
 
-if [ $1 ]
-then
-  herokuApp="$1"
+function create_heroku_addon () {
+	if heroku addons:info "$1" &> /dev/null; then
+		echo "Already installed $1"
+	else
+		echo "Installing $1"
+		heroku addons:create "$@"
+	fi
+}
 
-  echo "Getting ready to set environment variables for $herokuApp"
-  figaro heroku:set -e production --app $herokuApp
-
-  echo "Setting MAILER_URL"
-  heroku config:set MAILER_URL=$herokuApp.herokuapp.com --app $herokuApp
-
-  echo "Setting DEVISE_SECRET_KEY"
-  # generate a random string with 36 characters
-  token1=$(python -c 'import uuid; print (uuid.uuid4())')
-  heroku config:set DEVISE_SECRET_KEY=$token1 --app $herokuApp
-
-  echo "Setting SECRET_TOKEN"
-  # generate a random string with 36 characters
-  token2=$(python -c 'import uuid; print (uuid.uuid4())')
-  heroku config:set SECRET_TOKEN=$token2 --app $herokuApp
-
-  echo "Getting ready to install add-ons for $herokuApp"
-
-  echo "Installing Postgres"
-  heroku addons:create heroku-postgresql --app $herokuApp
-
-  echo "Installing SendGrid"
-  heroku addons:create sendgrid:starter --app $herokuApp
-
-  echo "Installing Memcachier"
-  heroku addons:create memcachier --app $herokuApp
-
-  echo "All done setting up env vars and add-ons."
-  echo "Pushing code to Heroku now. This will take a few minutes..."
-  git push heroku master
-
-  echo "Setting up the Heroku database"
-  heroku run rake db:migrate -a $herokuApp
-else
-  echo "Please add your Heroku app name to the end of the command."
-  echo "Usage: setup_heroku your_app_name"
+if [ $# -eq 0 ]; then
+	echo >&2 "Please add your Heroku app name to the end of the command."
+	echo >&2 "Usage: setup_heroku your_app_name"
+	exit 1
 fi
+
+export HEROKU_APP="$1"
+
+echo "Getting ready to set environment variables for $HEROKU_APP"
+figaro heroku:set -e production
+
+echo "Setting MAILER_URL"
+heroku config:set MAILER_URL="$HEROKU_APP.herokuapp.com"
+
+if [ -z "$(heroku config:get SECRET_TOKEN)" ]; then
+	echo "Setting SECRET_TOKEN"
+	# generate a random string with 36 characters
+	heroku config:set SECRET_TOKEN="$(bin/rake secret)"
+fi
+
+echo "Getting ready to install add-ons for $HEROKU_APP"
+
+create_heroku_addon heroku-postgresql
+
+create_heroku_addon sendgrid:starter
+
+create_heroku_addon memcachier
+
+create_heroku_addon quotaguard:starter
+
+echo "All done setting up env vars and add-ons."
+echo "Pushing code to Heroku now. This will take a few minutes..."
+git push heroku master
+
+echo "Setting up the Heroku database"
+heroku run bin/rake db:migrate


### PR DESCRIPTION
1. Stop provisioning DEVISE_SECRET_KEY since a separate setting for Devise is not needed with modern versions of Devise and Rails 4+ (cf. https://github.com/plataformatec/devise/pull/2835). The devise.rb initializer has been updated to allow the application to start without ENV['DEVISE_SECRET_KEY'], in which case Devise will use Rails.application.config.secret_key_base (controlled by ENV['SECRET_TOKEN'])
2. Allow the script to be run idempotently
3. Check if a Heroku add-on is installed before calling "heroku addons:create"
4. Check if SECRET_TOKEN is set before generating one
5. Use "rake secret" instead of Python for UUID generation, since this is a Rails project
6. Add quotaguard:starter addon (cf. https://github.com/codeforamerica/ohana-api/pull/415)